### PR TITLE
Uptaking imports changes with granular commits

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,8 @@ jobs:
     strategy:
       matrix:
         java:
+          - '8.0.382'
+          - '11.0.21'
           - '17.0.9'
         scala:
           - '2.13.11'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Two of the CBOR tests fail due to a bug in `CBOR-Java`. The bug was fixed [in th
 
 - [x] GitHub Actions are used to test across JDK 8, 11, 17 and Scala 2.13.11 and 3.3.1.
 
-- [ ] Import resolution code is in progress. Basic import resolution is implemented (files, environment variables, and URLs).
+- [x] Import resolution code is fully implemented, all tests pass.
 
 ## Special features in the Scala implementation of Dhall
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,9 @@ lazy val scall_core = (project in file("scall-core"))
     scalafmtFailOnErrors     := false, // Cannot disable the unicode surrogate pair error in Parser.scala?
     testFrameworks += munitFramework,
     Test / javaOptions ++= jdkModuleOptions,
+    // We need to run tests in forked JVM starting with the current directory set to the base resource directory.
+    // That base directory should contain `./dhall-lang` and all files below that.
+    Test / baseDirectory     := (Test / resourceDirectory).value,
     libraryDependencies ++= Seq(
       fastparse,
       munitTest,

--- a/github-scala-build-and-test.dhall
+++ b/github-scala-build-and-test.dhall
@@ -1,18 +1,12 @@
 let GithubActions =
       https://regadas.dev/github-actions-dhall/package.dhall
         sha256:71df44892a17abca817cfb35e2612d117f7fceec55114a6eb76b65a7eea4e6f4
-
-let matrix =
-      toMap { java = [ 
---"8.0.382", 
---"11.0.21", 
-"17.0.9",
- ], scala = [ 
-"2.13.11",
- ] }
+--  java versions 8.0.382, 11.0.21 and scala version 3.3.1 are to be added here
+let matrix = toMap { java = [ "17.0.9" ], scala = [ "2.13.11" ] }
 
 let setup =
-      [ GithubActions.steps.actions/checkout // { `with` = Some (toMap { submodules = "true" }) }
+      [     GithubActions.steps.actions/checkout
+        //  { `with` = Some (toMap { submodules = "true" }) }
       , GithubActions.steps.actions/cache
           { path =
               ''
@@ -21,19 +15,13 @@ let setup =
               ''
           , key = "sbt"
           , hashFiles =
-            [ "build.sbt"
-            , "project/plugins.sbt"
-            , "project/build.properties"
-            ]
+            [ "build.sbt", "project/plugins.sbt", "project/build.properties" ]
           }
       ]
 
 in  GithubActions.Workflow::{
     , name = "scall_build_and_test"
-    , on = GithubActions.On::{
-      , push = Some GithubActions.Push::{=}
-      --, pull_request = Some GithubActions.PullRequest::{=} -- disabling this will disable builds in PRs submitted from other people's forks
-      }
+    , on = GithubActions.On::{ push = Some GithubActions.Push::{=} }
     , jobs = toMap
         { checks = GithubActions.Job::{
           , name = Some "Check formatting"
@@ -50,39 +38,39 @@ in  GithubActions.Workflow::{
           , needs = Some [ "checks" ]
           , strategy = Some GithubActions.Strategy::{ matrix }
           , runs-on = GithubActions.types.RunsOn.ubuntu-latest
-          {-
-           permissions:
-             contents: read
-             actions: read
-             checks: write
-          -}
           , permissions =
-           let Permission = GithubActions.types.Permission
-            in let read =GithubActions.types.PermissionAccess.read
-             in let write = GithubActions.types.PermissionAccess.write
-              in Some [
-                { mapKey = Permission.actions, mapValue = read },
-                { mapKey = Permission.checks, mapValue  = write },
-                { mapKey = Permission.contents, mapValue= read },
-          ]
+              let Permission = GithubActions.types.Permission
+
+              in  let read = GithubActions.types.PermissionAccess.read
+
+                  in  let write = GithubActions.types.PermissionAccess.write
+
+                      in  Some
+                            [ { mapKey = Permission.actions, mapValue = read }
+                            , { mapKey = Permission.checks, mapValue = write }
+                            , { mapKey = Permission.contents, mapValue = read }
+                            ]
           , steps =
                 setup
-              # [
-                , GithubActions.steps.actions/setup-java
+              # [ GithubActions.steps.actions/setup-java
                     { java-version = "\${{ matrix.java}}" }
                 , GithubActions.steps.run
-                    { run = "sbt -DJDK_VERSION=\${{ matrix.java}} \"++\${{ matrix.scala}} test\"" }
+                    { run =
+                        "sbt -DJDK_VERSION=\${{ matrix.java}} \"++\${{ matrix.scala}} test\""
+                    }
                 , GithubActions.Step::{
-                                name = Some "Report test results",
-                                uses = Some "dorny/test-reporter@v1.7.0",
-                                `if` = Some "success() || failure()",
-                                `with` = Some (toMap {
-                                    name = "SBT tests",
-                                    path = "*/target/test-reports/*.xml",
-                                    reporter = "java-junit",
-                                    fail-on-error = "true",
-                                  }),
-                 }
+                  , name = Some "Report test results"
+                  , uses = Some "dorny/test-reporter@v1.7.0"
+                  , `if` = Some "success() || failure()"
+                  , `with` = Some
+                      ( toMap
+                          { name = "SBT tests"
+                          , path = "*/target/test-reports/*.xml"
+                          , reporter = "java-junit"
+                          , fail-on-error = "true"
+                          }
+                      )
+                  }
                 ]
           }
         }

--- a/github-scala-build-and-test.dhall
+++ b/github-scala-build-and-test.dhall
@@ -1,8 +1,9 @@
 let GithubActions =
       https://regadas.dev/github-actions-dhall/package.dhall
         sha256:71df44892a17abca817cfb35e2612d117f7fceec55114a6eb76b65a7eea4e6f4
---  java versions 8.0.382, 11.0.21 and scala version 3.3.1 are to be added here
-let matrix = toMap { java = [ "17.0.9" ], scala = [ "2.13.11" ] }
+
+let matrix =
+      toMap { java = [ "8.0.382", "11.0.21", "17.0.9" ], scala = [ "2.13.11" ] }
 
 let setup =
       [     GithubActions.steps.actions/checkout

--- a/reformat_all_code.sh
+++ b/reformat_all_code.sh
@@ -1,1 +1,2 @@
 sbt scalafmtAll scalafmtSbt
+dhall format github-scala-build-and-test.dhall

--- a/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
@@ -20,7 +20,7 @@ import scala.util.chaining.scalaUtilChainingOps
 import scala.util.{Failure, Success, Try}
 
 object ImportResolution {
-  // TODO: missing sha256:... should be resolved if a cached value is available.
+
   def chainWith[E](parent: ImportType[E], child: ImportType[E]): ImportType[E] = (parent, child) match {
     case (Remote(ImportURL(scheme1, authority1, path1, query1), headers1), Path(Here, path2))              =>
       Remote(ImportURL(scheme1, authority1, path1 chain path2, query1), headers1)
@@ -31,7 +31,7 @@ object ImportResolution {
     case _                                                                                                 => child
   }
 
-  val corsHeader = "Access-Control-Allow-Origin"
+  val corsHeader = "Access-Control-Allow-Origin".toLowerCase
 
   // This function returns `None` if there is no error in CORS compliance.
   def corsComplianceError(parent: ImportType[Expression], child: ImportType[Expression], responseHeaders: Map[String, Seq[String]]): Option[String] =
@@ -40,7 +40,7 @@ object ImportResolution {
       case (Remote(ImportURL(scheme1, authority1, path1, query1), headers1), Remote(ImportURL(scheme2, authority2, path2, query2), headers2)) =>
         if (scheme1 == scheme2 && authority1 == authority2) None
         else
-          responseHeaders.get(corsHeader) match {
+          responseHeaders.map { case (k, v) => (k.toLowerCase, v) }.get(corsHeader) match {
             case Some(Seq("*"))                                                                 => None
             case Some(Seq(other)) if other.toLowerCase == s"$scheme2://$authority2".toLowerCase => None
             case Some(_)                                                                        =>

--- a/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
@@ -262,7 +262,7 @@ object ImportResolution {
             case Some(remoteOrigin) =>
               val (result, state01) = resolveImportsStep(defaultHeadersLocation, visited, parent).run(stateGamma0)
               result match {
-                case Resolved(expr)                           =>
+                case Resolved(expr)             =>
                   val headersForOrigin: Iterable[(String, String)] = (expr | typeOfGenericHeadersForAllHosts).inferType match {
                     case TypecheckResult.Valid(_)        =>
                       expr.scheme match {

--- a/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
@@ -6,8 +6,8 @@ import io.chymyst.dhall.CBORmodel.CBytes
 import io.chymyst.dhall.ImportResolution.ImportContext
 import io.chymyst.dhall.ImportResolutionResult._
 import io.chymyst.dhall.Parser.StringAsDhallExpression
-import io.chymyst.dhall.Syntax.{DhallFile, Expression}
 import io.chymyst.dhall.Syntax.ExpressionScheme._
+import io.chymyst.dhall.Syntax.{DhallFile, Expression}
 import io.chymyst.dhall.SyntaxConstants.FilePrefix.Here
 import io.chymyst.dhall.SyntaxConstants.ImportMode.Location
 import io.chymyst.dhall.SyntaxConstants.ImportType.{Path, Remote}
@@ -15,7 +15,6 @@ import io.chymyst.dhall.SyntaxConstants.Operator.Alternative
 import io.chymyst.dhall.SyntaxConstants._
 
 import java.nio.file.{Files, Paths}
-import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.chaining.scalaUtilChainingOps
 import scala.util.{Failure, Success, Try}
 

--- a/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
@@ -427,9 +427,11 @@ object ImportResolution {
           // Add the new resolved expression to the import context.
           newState match {
             case (result2, state2) =>
-              result2.flatMap(validateHashAndCacheResolved(_, child.digest)) match {
+              // Corner case: import as Location must not attempt to use the digest cache.
+              val effectiveDigest = if (child.importMode == ImportMode.Location) None else child.digest
+              result2.flatMap(validateHashAndCacheResolved(_, effectiveDigest)) match {
                 case Resolved(r) => (result2, state2.copy(state2.resolved.updated(child, r)))
-                case _           => newState
+                case failure     => (failure, state2)
               }
           }
 

--- a/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/ImportResolution.scala
@@ -157,7 +157,7 @@ object ImportResolution {
 
   def printVisited(visited: Seq[Import[Expression]]): String = visited.map(_.toDhall).mkString("[", ", ", "]")
 
-  private def extractHeaders(h: Expression, keyName: String, valueName: String): Iterable[(String, String)] = h.scheme match {
+  private def extractHeaders(h: Expression, keyName: String, valueName: String): Iterable[(String, String)] = h.betaNormalized.scheme match {
     case EmptyList(_)        => emptyHeadersForHost
     case NonEmptyList(exprs) =>
       exprs.map(_.scheme).map { case d @ RecordLiteral(_) =>
@@ -260,7 +260,7 @@ object ImportResolution {
                 case Resolved(expr)             =>
                   val headersForOrigin: Iterable[(String, String)] = (expr | typeOfGenericHeadersForAllHosts).inferType match {
                     case TypecheckResult.Valid(_)        =>
-                      expr.scheme match {
+                      expr.betaNormalized.scheme match { // TODO report issue: imports.md does not say that headers must be beta-normalized before use, but tests require that.
                         case NonEmptyList(exprs) =>
                           exprs.find {
                             case Expression(r @ RecordLiteral(_)) =>

--- a/scall-core/src/main/scala/io/chymyst/dhall/LRUCache.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/LRUCache.scala
@@ -1,7 +1,6 @@
 package io.chymyst.dhall
 
-import io.chymyst.dhall.Syntax.{Expression, ExpressionScheme}
-import io.chymyst.dhall.TypeCheck.KnownVars
+import io.chymyst.dhall.Syntax.Expression
 
 import java.util
 import scala.collection.mutable

--- a/scall-core/src/main/scala/io/chymyst/dhall/Parser.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/Parser.scala
@@ -9,7 +9,6 @@ import io.chymyst.dhall.SyntaxConstants.{ConstructorName, FieldName, ImportType,
 import io.chymyst.dhall.TypeCheck._Type
 
 import java.io.InputStream
-import java.nio.file.Paths
 import java.time.LocalDate
 import scala.util.{Failure, Success, Try}
 

--- a/scall-core/src/main/scala/io/chymyst/dhall/Semantics.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/Semantics.scala
@@ -1,18 +1,16 @@
 package io.chymyst.dhall
 
-import io.chymyst.dhall.CBORmodel.CBytes
 import io.chymyst.dhall.Applicative.ApplicativeOps
 import io.chymyst.dhall.CBORmodel.CBytes
 import io.chymyst.dhall.Syntax.Expression.v
 import io.chymyst.dhall.Syntax.ExpressionScheme._
 import io.chymyst.dhall.Syntax.{Expression, ExpressionScheme, Natural, PathComponent}
-import io.chymyst.dhall.SyntaxConstants.Builtin.{ListFold, ListLength, Natural, NaturalFold, NaturalSubtract}
+import io.chymyst.dhall.SyntaxConstants.Builtin.{ListFold, ListLength, Natural, NaturalSubtract}
 import io.chymyst.dhall.SyntaxConstants.Constant.{False, True}
 import io.chymyst.dhall.SyntaxConstants.Operator.ListAppend
 import io.chymyst.dhall.SyntaxConstants._
 
 import java.security.MessageDigest
-import java.time.LocalDateTime
 import java.util.regex.Pattern
 import scala.collection.mutable
 import scala.util.chaining.scalaUtilChainingOps

--- a/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
@@ -835,7 +835,8 @@ object Syntax {
 
     def inferTypeWith(gamma: TypeCheck.KnownVars): TypecheckResult[Expression] = TypeCheck.inferType(gamma, this)
 
-    def wellTypedBetaNormalize(gamma: TypeCheck.KnownVars): TypecheckResult[Expression] = inferTypeWith(gamma).map(_ => betaNormalized)
+    def typeCheckAndBetaNormalize(gamma: TypeCheck.KnownVars = TypeCheck.KnownVars.empty): TypecheckResult[Expression] =
+      inferTypeWith(gamma).map(_ => betaNormalized)
 
     def inferAndValidateTypeWith(gamma: TypeCheck.KnownVars): TypecheckResult[Expression] = for {
       t <- TypeCheck.inferType(gamma, this)
@@ -924,10 +925,13 @@ object Syntax {
         case DateLiteral(year, month, day)          => f"$year%04d-$month%02d-$day%02d"
         case t @ TimeLiteral(_, _, _, _)            => t.toString
         case t @ TimeZoneLiteral(_)                 => f"${if (t.isPositive) "+" else "-"}${t.hours}%02d:${t.minutes}%02d"
-        case RecordType(defs)                       => "{ " + defs.map { case (name, expr) => name.name + ": " + expr.atPrecedence(p) }.mkString(", ") + " }"
-        case RecordLiteral(defs)                    => "{ " + defs.map { case (name, expr) => name.name + " = " + expr.atPrecedence(TermPrecedence.lowest) }.mkString(", ") + " }"
-        case UnionType(defs)                        =>
-          "< " + defs.map { case (name, expr) => name.name + expr.map(_.atPrecedence(p)).map(": " + _).getOrElse("") }.mkString(" | ") + " > "
+        case r @ RecordType(_)                      =>
+          "{ " + r.sorted.defs.map { case (name, expr) => name.name + ": " + expr.atPrecedence(TermPrecedence.lowest) }.mkString(", ") + " }"
+        case r @ RecordLiteral(_)                   =>
+          "{ " + r.sorted.defs.map { case (name, expr) => name.name + " = " + expr.atPrecedence(TermPrecedence.lowest) }.mkString(", ") + " }"
+        case u @ UnionType(_)                       =>
+          "< " + u.sorted.defs
+            .map { case (name, expr) => name.name + expr.map(_.atPrecedence(TermPrecedence.lowest)).map(": " + _).getOrElse("") }.mkString(" | ") + " > "
         case ShowConstructor(data)                  => "showConstructor " + data.atPrecedence(p)
         case Import(importType, importMode, digest) =>
           val digestString     = digest.map(b => " sha256:" + b.hex.toLowerCase).getOrElse("")

--- a/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
@@ -235,7 +235,7 @@ object SyntaxConstants {
     def allowedToImportAnother(anotherImportType: ImportType[_]): Boolean =
       this.safetyLevelRequired <= anotherImportType.safetyLevelRequired
 
-    def remoteOrigin: Option[String] = None
+    def remoteOrigin: Option[(Scheme, String)] = None
 
     def hasUserHeaders: Boolean = false
   }
@@ -248,7 +248,7 @@ object SyntaxConstants {
     final case class Remote[E](url: ImportURL, headers: Option[E]) extends ImportType[E] {
       override def safetyLevelRequired: Int = 0 // This can import itself or Missing.
 
-      override def remoteOrigin: Option[String] = Some(url.httpAuthority)
+      override def remoteOrigin: Option[(Scheme, String)] = Some(url.scheme, url.authority)
 
       override def hasUserHeaders: Boolean = headers.nonEmpty
     }

--- a/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
+++ b/scall-core/src/main/scala/io/chymyst/dhall/Syntax.scala
@@ -1,8 +1,6 @@
 package io.chymyst.dhall
 
 import enumeratum._
-import io.chymyst.dhall.CBORmodel.CBytes
-import io.chymyst.dhall.Grammar.TextLiteralNoInterp
 import io.chymyst.dhall.Applicative.{ApplicativeOps, seqOption, seqSeq, seqTuple2, seqTuple3}
 import io.chymyst.dhall.CBORmodel.CBytes
 import io.chymyst.dhall.Grammar.{TextLiteralNoInterp, hexStringToByteArray}
@@ -11,10 +9,8 @@ import io.chymyst.dhall.Syntax.ExpressionScheme._
 import io.chymyst.dhall.SyntaxConstants.Operator.Plus
 import io.chymyst.dhall.SyntaxConstants._
 
-import java.nio.file.{Path, Paths}
-import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
-import java.util.concurrent.atomic.AtomicReference
-import scala.collection.mutable
+import java.nio.file.Paths
+import java.time.{LocalDate, LocalTime, ZoneOffset}
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.language.implicitConversions
 import scala.util.chaining.scalaUtilChainingOps
@@ -796,12 +792,10 @@ object Syntax {
       def chainWith[E](parent: Import[E], child: Import[E]): Import[E] =
         child.copy(importType = ImportResolution.chainWith(parent.importType, child.importType))
 
-      implicit def ofJavaPath(path: java.nio.file.Path): Import[Nothing] = Import(
-        // Workaround: use current file as import path, import as code without sha256.
-        ImportType.Path(FilePrefix.Absolute, SyntaxConstants.FilePath(path.iterator.asScala.toSeq.map(_.toString))),
-        ImportMode.Code,
-        digest = None,
-      )
+      implicit def ofJavaPath(path: java.nio.file.Path): Import[Nothing] = {
+        val prefix = if (path.isAbsolute) FilePrefix.Absolute else FilePrefix.Here
+        Import(ImportType.Path(prefix, SyntaxConstants.FilePath(path.iterator.asScala.toSeq.map(_.toString))), ImportMode.Code, digest = None)
+      }
 
       implicit def ofJavaFile(file: java.io.File): Import[Nothing] = ofJavaPath(file.toPath)
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -33,77 +33,91 @@ object DhallImportResolutionSuite {
 class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with ResourceFiles {
 
   def setupEnvironment[R](code: => R): R = {
-    val tempDir = os.temp.dir(root / "tmp", deleteOnExit = true)
+    val tempDir     = os.temp.dir(root / "tmp", deleteOnExit = true)
+    val oldUserHome = System.getProperty("user.home")
     try {
       os.copy(from = os.Path(resourceAsFile("dhall-lang/tests/import/cache").get.getAbsolutePath), to = tempDir, replaceExisting = true)
       val dhallHome = resourceAsFile("dhall-lang/tests/import/home").get.getAbsolutePath
       System.setProperty("user.home", dhallHome)
       val envVars   = Seq("DHALL_TEST_VAR" -> "6 * 7", "XDG_CACHE_HOME" -> tempDir.toNIO.toAbsolutePath.toString, "HOME" -> dhallHome)
       runInFakeEnvironmentWith(envVars: _*)(code)
-    } finally os.remove.all(tempDir)
+    } finally {
+      os.remove.all(tempDir)
+      System.setProperty("user.home", oldUserHome)
+    }
   }
 
   test("import resolution success") {
-    setupEnvironment {
-      val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/success", Some("A.dhall")).map { file =>
-        val parentPath                          = resourceAsFile("dhall-lang").get.toPath.getParent
-        val relativePathForTest                 = parentPath.relativize(file.toPath)
-        val envVarsFile                         = new File(file.getAbsolutePath.replace("A.dhall", "ENV.dhall"))
-        val extraEnvVars: Seq[(String, String)] = DhallImportResolutionSuite.readHeadersFromEnv(envVarsFile)
-        val validationFile                      = new File(file.getAbsolutePath.replace("A.dhall", "B.dhall"))
-        // if (envVarsFile.exists) println(s"DEBUG: env vars for file ${file.toPath} are $extraEnvVars")
-        runInFakeEnvironmentWith(extraEnvVars: _*) {
-          val result = Try {
-            val Parsed.Success(DhallFile(_, ourResult), _)        = Parser.parseDhallStream(new FileInputStream(file))
-            val Parsed.Success(DhallFile(_, validationResult), _) = Parser.parseDhallStream(new FileInputStream(validationFile))
-            // TODO report issue: the test dhall-lang/tests/import/success/unit/ImportRelativeToHomeB.dhall should be "hello" ++ " world" because tests should not beta-normalize entire expressions (only imported sub-expressions)
-            val x                                                 = ourResult.resolveImports(relativePathForTest) // We should not beta-normalize entire expressions. // .typeCheckAndBetaNormalize().unsafeGet
-            val y                                                 = validationResult.resolveImports(relativePathForTest)
+    val parentPath         = resourceAsFile("dhall-lang").get.toPath.getParent
+    val currentDirForTests = parentPath.toFile.getAbsoluteFile
+    val oldUserDir         = System.getProperty("user.dir")
+    try {
+      System.setProperty("user.dir", currentDirForTests.getAbsolutePath)
+      setupEnvironment {
+        val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/success", Some("A.dhall")).map { file =>
+          val relativePathForTest                 = parentPath.relativize(file.toPath)
+          val envVarsFile                         = new File(file.getAbsolutePath.replace("A.dhall", "ENV.dhall"))
+          val extraEnvVars: Seq[(String, String)] = DhallImportResolutionSuite.readHeadersFromEnv(envVarsFile)
+          val validationFile                      = new File(file.getAbsolutePath.replace("A.dhall", "B.dhall"))
+          // if (envVarsFile.exists) println(s"DEBUG: env vars for file ${file.toPath} are $extraEnvVars")
+          runInFakeEnvironmentWith(extraEnvVars: _*) {
+            val result = Try {
+              val Parsed.Success(DhallFile(_, ourResult), _)        = Parser.parseDhallStream(new FileInputStream(file))
+              val Parsed.Success(DhallFile(_, validationResult), _) = Parser.parseDhallStream(new FileInputStream(validationFile))
+              // TODO report issue: the test dhall-lang/tests/import/success/unit/ImportRelativeToHomeB.dhall should be "hello" ++ " world" because tests should not beta-normalize entire expressions (only imported sub-expressions)
+              val x                                                 = ourResult.resolveImports(relativePathForTest) // We should not beta-normalize entire expressions.
+              val y                                                 = validationResult.resolveImports(relativePathForTest)
 
-            if (x.toDhall != y.toDhall)
-              println(
-                s"DEBUG: ${file.getName}: The Dhall texts differ. Our parser gives:\n${ourResult.toDhall}\n\t\tafter beta-normalization:\n${x.toDhall}\n\t\texpected correct answer:\n${y.toDhall}\n"
-              )
-            else if (x != y)
-              println(
-                s"DEBUG: ${file.getName}: The expressions differ. Our parser gives:\n${ourResult.toDhall}\n\t\tafter beta-normalization:\n${x.toDhall}\n\t\tDhall texts are equal but expressions differ: our normalized expression is:\n$x\n\t\tThe expected correct expression is:\n$y\n"
-              )
+              if (x.toDhall != y.toDhall)
+                println(
+                  s"DEBUG: ${file.getName}: The Dhall texts differ. Our parser gives:\n${ourResult.toDhall}\n\t\tafter beta-normalization:\n${x.toDhall}\n\t\texpected correct answer:\n${y.toDhall}\n"
+                )
+              else if (x != y)
+                println(
+                  s"DEBUG: ${file.getName}: The expressions differ. Our parser gives:\n${ourResult.toDhall}\n\t\tafter beta-normalization:\n${x.toDhall}\n\t\tDhall texts are equal but expressions differ: our normalized expression is:\n$x\n\t\tThe expected correct expression is:\n$y\n"
+                )
 
-            expect(x.toDhall == y.toDhall && x == y)
-            file.getName
+              expect(x.toDhall == y.toDhall && x == y)
+              file.getName
+            }
+            if (result.isFailure)
+              println(s"${file.getName}: ${result.failed.get}\n${printThrowable(result.failed.get)}")
+            result
           }
-          if (result.isFailure)
-            println(s"${file.getName}: ${result.failed.get}\n${printThrowable(result.failed.get)}")
-          result
         }
-
+        TestUtils.requireSuccessAtLeast(72, results, 15)
       }
-      TestUtils.requireSuccessAtLeast(72, results, 15)
-    }
+    } finally System.setProperty("user.dir", oldUserDir)
   }
 
   test("import resolution failure") {
     setupEnvironment {
-      val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/failure", Some(".dhall"))
-        .filterNot(_.getAbsolutePath endsWith "ENV.dhall") // Otherwise we cannot distinguish between test files and their ENV files.
-        .map { file =>
-          val parentPath                          = resourceAsFile("dhall-lang").get.toPath.getParent
-          val relativePathForTest                 = parentPath.relativize(file.toPath)
-          val envVarsFile                         = new File(file.getAbsolutePath.replace(".dhall", "ENV.dhall"))
-          val extraEnvVars: Seq[(String, String)] = DhallImportResolutionSuite.readHeadersFromEnv(envVarsFile)
-          // if (envVarsFile.exists) println(s"DEBUG: env vars for file ${file.toPath} are $extraEnvVars")
-          runInFakeEnvironmentWith(extraEnvVars: _*) {
-            val result = Try {
-              val Parsed.Success(DhallFile(_, ourResult), _) = Parser.parseDhallStream(new FileInputStream(file))
-              val x                                          = Try(ourResult.resolveImports(relativePathForTest))
-              expect(x.isFailure)
-              file.getName
+      val parentPath         = resourceAsFile("dhall-lang").get.toPath.getParent
+      val currentDirForTests = parentPath.toFile.getAbsoluteFile
+      val oldUserDir         = System.getProperty("user.dir")
+      try {
+        System.setProperty("user.dir", currentDirForTests.getAbsolutePath)
+        val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/failure", Some(".dhall"))
+          .filterNot(_.getAbsolutePath endsWith "ENV.dhall") // Otherwise we cannot distinguish between test files and their ENV files.
+          .map { file =>
+            val relativePathForTest                 = parentPath.relativize(file.toPath)
+            val envVarsFile                         = new File(file.getAbsolutePath.replace(".dhall", "ENV.dhall"))
+            val extraEnvVars: Seq[(String, String)] = DhallImportResolutionSuite.readHeadersFromEnv(envVarsFile)
+            // if (envVarsFile.exists) println(s"DEBUG: env vars for file ${file.toPath} are $extraEnvVars")
+            runInFakeEnvironmentWith(extraEnvVars: _*) {
+              val result = Try {
+                val Parsed.Success(DhallFile(_, ourResult), _) = Parser.parseDhallStream(new FileInputStream(file))
+                val x                                          = Try(ourResult.resolveImports(relativePathForTest))
+                expect(x.isFailure)
+                file.getName
+              }
+              if (result.isFailure) println(s"${file.getName}: ${result.failed.get.getMessage}")
+              result
             }
-            if (result.isFailure) println(s"${file.getName}: ${result.failed.get.getMessage}")
-            result
           }
-        }
-      TestUtils.requireSuccessAtLeast(24, results, 4)
+
+        TestUtils.requireSuccessAtLeast(24, results, 4)
+      } finally System.setProperty("user.dir", oldUserDir)
     }
   }
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -77,7 +77,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
         }
 
       }
-      TestUtils.requireSuccessAtLeast(72, results, 19)
+      TestUtils.requireSuccessAtLeast(72, results, 16)
     }
   }
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -77,7 +77,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
         }
 
       }
-      TestUtils.requireSuccessAtLeast(72, results, 16)
+      TestUtils.requireSuccessAtLeast(72, results, 13)
     }
   }
 
@@ -94,7 +94,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
         if (result.isFailure) println(s"${file.getName}: ${result.failed.get.getMessage}")
         result
       }
-      TestUtils.requireSuccessAtLeast(25, results, 4)
+      TestUtils.requireSuccessAtLeast(25, results, 2)
     }
   }
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -77,7 +77,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
         }
 
       }
-      TestUtils.requireSuccessAtLeast(72, results, 43)
+      TestUtils.requireSuccessAtLeast(72, results, 19)
     }
   }
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -56,8 +56,9 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
           val result = Try {
             val Parsed.Success(DhallFile(_, ourResult), _)        = Parser.parseDhallStream(new FileInputStream(file))
             val Parsed.Success(DhallFile(_, validationResult), _) = Parser.parseDhallStream(new FileInputStream(validationFile))
-            val x                                                 = ourResult.resolveImports(file.toPath)
-            val y                                                 = validationResult
+            // TODO report issue: the test dhall-lang/tests/import/success/unit/ImportRelativeToHomeB.dhall should be "hello" ++ " world" because tests should not beta-normalize entire expressions (only imported sub-expressions)
+            val x                                                 = ourResult.resolveImports(relativePathForTest) // We should not beta-normalize entire expressions. // .typeCheckAndBetaNormalize().unsafeGet
+            val y                                                 = validationResult.resolveImports(relativePathForTest)
 
             if (x.toDhall != y.toDhall)
               println(
@@ -77,24 +78,32 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
         }
 
       }
-      TestUtils.requireSuccessAtLeast(72, results, 13)
+      TestUtils.requireSuccessAtLeast(72, results, 15)
     }
   }
 
   test("import resolution failure") {
     setupEnvironment {
-      val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/failure", Some(".dhall")).map { file =>
-        val result = Try {
-          val Parsed.Success(DhallFile(_, ourResult), _) = Parser.parseDhallStream(new FileInputStream(file))
-          // TODO: resolve with ./dhall-lang/tests/...dhall as parent import
-          val x                                          = Try(ourResult.resolveImports(file.toPath))
-          expect(x.isFailure)
-          file.getName
+      val results: Seq[Try[String]] = enumerateResourceFiles("dhall-lang/tests/import/failure", Some(".dhall"))
+        .filterNot(_.getAbsolutePath endsWith "ENV.dhall") // Otherwise we cannot distinguish between test files and their ENV files.
+        .map { file =>
+          val parentPath                          = resourceAsFile("dhall-lang").get.toPath.getParent
+          val relativePathForTest                 = parentPath.relativize(file.toPath)
+          val envVarsFile                         = new File(file.getAbsolutePath.replace(".dhall", "ENV.dhall"))
+          val extraEnvVars: Seq[(String, String)] = DhallImportResolutionSuite.readHeadersFromEnv(envVarsFile)
+          // if (envVarsFile.exists) println(s"DEBUG: env vars for file ${file.toPath} are $extraEnvVars")
+          runInFakeEnvironmentWith(extraEnvVars: _*) {
+            val result = Try {
+              val Parsed.Success(DhallFile(_, ourResult), _) = Parser.parseDhallStream(new FileInputStream(file))
+              val x                                          = Try(ourResult.resolveImports(relativePathForTest))
+              expect(x.isFailure)
+              file.getName
+            }
+            if (result.isFailure) println(s"${file.getName}: ${result.failed.get.getMessage}")
+            result
+          }
         }
-        if (result.isFailure) println(s"${file.getName}: ${result.failed.get.getMessage}")
-        result
-      }
-      TestUtils.requireSuccessAtLeast(25, results, 2)
+      TestUtils.requireSuccessAtLeast(24, results, 4)
     }
   }
 

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallImportResolutionSuite.scala
@@ -64,9 +64,10 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
             val result = Try {
               val Parsed.Success(DhallFile(_, ourResult), _)        = Parser.parseDhallStream(new FileInputStream(file))
               val Parsed.Success(DhallFile(_, validationResult), _) = Parser.parseDhallStream(new FileInputStream(validationFile))
-              // TODO report issue: the test dhall-lang/tests/import/success/unit/ImportRelativeToHomeB.dhall should be "hello" ++ " world" because tests should not beta-normalize entire expressions (only imported sub-expressions)
-              val x                                                 = ourResult.resolveImports(relativePathForTest) // We should not beta-normalize entire expressions.
-              val y                                                 = validationResult.resolveImports(relativePathForTest)
+              val x                                                 = ourResult.resolveImports(
+                relativePathForTest
+              ) // Here we must avoid beta-normalizing entire expressions. Only the import contents must be normalized.
+              val y = validationResult.resolveImports(relativePathForTest)
 
               if (x.toDhall != y.toDhall)
                 println(
@@ -85,7 +86,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
             result
           }
         }
-        TestUtils.requireSuccessAtLeast(72, results, 15)
+        TestUtils.requireSuccessAtLeast(72, results, 0)
       }
     } finally System.setProperty("user.dir", oldUserDir)
   }
@@ -116,7 +117,7 @@ class DhallImportResolutionSuite extends FunSuite with OverrideEnvironment with 
             }
           }
 
-        TestUtils.requireSuccessAtLeast(24, results, 4)
+        TestUtils.requireSuccessAtLeast(24, results, 0)
       } finally System.setProperty("user.dir", oldUserDir)
     }
   }

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor1Suite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor1Suite.scala
@@ -27,7 +27,7 @@ class DhallParserAndCbor1Suite extends FunSuite {
       result
     }
     println(s"Success count: ${results.count(_.isSuccess)}\nFailure count: ${results.count(_.isFailure)}")
-    expect(results.count(_.isFailure) == 0)
+    TestUtils.requireSuccessAtLeast(284, results)
   }
 
   test("validate CBOR writing for standard examples") {
@@ -129,7 +129,7 @@ class DhallParserAndCbor1Suite extends FunSuite {
       result
     }
     println(s"Success count: ${results.count(_.isSuccess)}\nFailure count: ${results.count(_.isFailure)}")
-    expect(results.count(_.isFailure) == 0)
+   TestUtils.requireSuccessAtLeast(82, results)
   }
 
   test("validate binary decoding/failure") {
@@ -148,6 +148,6 @@ class DhallParserAndCbor1Suite extends FunSuite {
       result
     }
     println(s"Success count: ${results.count(_.isSuccess)}\nFailure count: ${results.count(_.isFailure)}")
-    expect(results.count(_.isFailure) == 0)
+    TestUtils.requireSuccessAtLeast(9, results)
   }
 }

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor1Suite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor1Suite.scala
@@ -129,7 +129,7 @@ class DhallParserAndCbor1Suite extends FunSuite {
       result
     }
     println(s"Success count: ${results.count(_.isSuccess)}\nFailure count: ${results.count(_.isFailure)}")
-   TestUtils.requireSuccessAtLeast(82, results)
+    TestUtils.requireSuccessAtLeast(82, results)
   }
 
   test("validate binary decoding/failure") {

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor2Suite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor2Suite.scala
@@ -35,8 +35,8 @@ class DhallParserAndCbor2Suite extends FunSuite {
                    }
       } yield result2
       result match {
-        case Failure(exception) => println(exception.getMessage)
-        case Success(value)     => println(file.getAbsolutePath)
+        case Failure(exception) => println("For file " + file.getAbsolutePath + ", error: " + exception.getMessage)
+        case Success(value)     => // println(file.getAbsolutePath)
       }
       result
     }

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor2Suite.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/DhallParserAndCbor2Suite.scala
@@ -147,7 +147,7 @@ class DhallParserAndCbor2Suite extends FunSuite {
     println(s"Success count: ${results.count(_.isSuccess)}\nFailure count: ${results
         .count(_.isFailure)}\nCBOR expression mismatch count: ${results.filter(_.isFailure).count(_.failed.get.getMessage.contains("expression differs"))}")
     results.filter(_.isFailure).map(_.failed.get.getMessage).foreach(println)
-    expect(results.count(_.isFailure) == 0)
+    TestUtils.requireSuccessAtLeast(284, results)
   }
 
   test("validate binary decoding/success") {

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/SimpleImportResolutionTest.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/SimpleImportResolutionTest.scala
@@ -10,7 +10,7 @@ import io.chymyst.dhall.Syntax.{DhallFile, Expression}
 import io.chymyst.dhall.SyntaxConstants.{Builtin, ConstructorName, FieldName, FilePrefix, ImportType, VarName}
 import io.chymyst.dhall.TypeCheck._Type
 import io.chymyst.dhall.TypecheckResult.Valid
-import io.chymyst.dhall.{Parser, SyntaxConstants, TypecheckResult}
+import io.chymyst.dhall.{Parser, Semantics, SyntaxConstants, TypecheckResult}
 import munit.FunSuite
 
 import java.io.FileInputStream
@@ -66,4 +66,20 @@ class SimpleImportResolutionTest extends FunSuite {
       expect(Try(string.dhall.resolveImports(Paths.get("."))).isFailure)
     }
   }
+
+  test("do not recover from sha mismatch") {
+    val file  = resourceAsFile("dhall-lang/Prelude/Bool/and.dhall").get.toPath
+    val expr1 = "./and.dhall sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? 0".dhall
+    expect(Try(expr1.resolveImports(file)).isFailure)
+    val expr2 = "./and.dhall sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".dhall
+    expect(Try(expr2.resolveImports(file)).isFailure)
+  }
+
+  test("correct sha256 check") {
+    val expr1 = "./some/import.dhall as Location".dhall
+    expect(Semantics.semanticHash(expr1.resolveImports(), Paths.get(".")) == "de93ce8633ee0cbc9c4d4351cafcd82965c5a7c221d28ad194900ead38887617")
+    val expr2 = "./some/import.dhall sha256:efc43103e49b56c5bf089db8e0365bbfc455b8a2f0dc6ee5727a3586f85969fd as Location".dhall
+    expect(Semantics.semanticHash(expr2.resolveImports(), Paths.get(".")) == "de93ce8633ee0cbc9c4d4351cafcd82965c5a7c221d28ad194900ead38887617")
+  }
+
 }

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/SimplePreludeTest.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/SimplePreludeTest.scala
@@ -36,7 +36,7 @@ class SimplePreludeTest extends FunSuite with TestTimeouts {
     expect(!expr.inferType.isValid) // Type-checking fails without first resolving imports.
     val resolved      = expr.resolveImports(path)
     expect(resolved.isInstanceOf[Expression])
-    println("resolved sort.dhall beta-normalized without typechecking:\n" + resolved.betaNormalized.toDhall)
+    // println("resolved sort.dhall beta-normalized without typechecking:\n" + resolved.betaNormalized.toDhall)
     val smallListTest = resolved("[3, 2]".dhall).betaNormalized
     println(s"sort [3, 2] = ${smallListTest.toDhall}")
     println(s"sort [4, 3, 2, 1] = ${resolved("[4, 3, 2, 1]".dhall).betaNormalized}")

--- a/scall-core/src/test/scala/io/chymyst/dhall/unit/TestUtils.scala
+++ b/scall-core/src/test/scala/io/chymyst/dhall/unit/TestUtils.scala
@@ -92,9 +92,11 @@ object TestUtils {
   }
 
   def requireSuccessAtLeast(totalTests: Int, results: Seq[Try[_]], allowFailures: Int = 0) = {
-    val failures  = results.count(_.isFailure)
-    val successes = results.count(_.isSuccess)
-    println(s"Success count: $successes\nFailure count: $failures")
+    val failures          = results.count(_.isFailure)
+    val successes         = results.count(_.isSuccess)
+    val unexpectedSuccess = math.max(0, successes - (totalTests - allowFailures))
+    println(s"Success count: $successes, failure count: $failures${if (unexpectedSuccess > 0) s"but the success count is $unexpectedSuccess more than expected."
+      else "."}")
     expect(failures <= allowFailures && successes >= totalTests - allowFailures)
   }
 


### PR DESCRIPTION
Many tests started failing mysteriously after a full implementation of the imports algorithm.

This PR will uptake the changes in small commits to keep tests passing.