### PR TITLE
Implement Okasaki's red-black tree in Dhall

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,8 @@
 # Roadmap for Dhall-related projects
 
-- Finish the tutorial book and publish it (depends on finishing SOFP first).
+
++ Finish the tutorial book and publish it (depends on finishing SOFP first).
+- Begin with µDhall and do everything all over. Use AI for menial work.
 - Rewrite all algorithms to be stack-safe, including parsing. Add tests for deeply nested values.
 - Rewrite the type checking and normal form algorithms using ∀-spines instead of nested forms, without functional changes. This is a pre-requisite for the one-step type inference. (Not sure whether also λ-spines are required for this to work.)
 - Implement parsing enhancements, without changing normal forms. (See below.)

--- a/tutorial/BenchMergeSorted.dhall
+++ b/tutorial/BenchMergeSorted.dhall
@@ -1,0 +1,50 @@
+let lib =
+      ./SortNatLib.dhall
+        sha256:bf096188342c8e307414afa71a04dc2cddb8ff2b8cb433f6646891e505f0f77c
+
+let bench =
+      ./Benchmark.dhall
+        sha256:dd03a83a9605b1a1ad04c3806e9eb3f5ff6e21bbf3ec43b2b6b78b4bc28e38cf
+
+let benchmark = bench.benchmark
+
+let nilNat = lib.nilNat
+
+let ListNat = lib.ListNat
+
+let consNat = lib.consNat
+
+let concatNat = lib.concatNat
+
+let ListNat/fromList = lib.ListNat/fromList
+
+let ListNat/toList = lib.ListNat/toList
+
+let ListNat/partitionSorted = lib.ListNat/partitionSorted
+
+let mergeSorted = lib.mergeSorted
+
+let testMergeSorted = lib.testMergeSorted
+
+let makeListNat = lib.makeListNat
+
+let ListNat/mergeSorted = lib.ListNat/mergeSorted
+
+let PairLists = lib.PairLists
+
+let iterations = env:N ? 3
+
+let size = env:S ? 3
+
+let makePair
+    : Natural → PairLists
+    = λ(n : Natural) → { _1 = makeListNat n 0 2, _2 = makeListNat n 1 2 }
+
+let runMerge =
+      λ(pair : PairLists) → ListNat/toList (ListNat/mergeSorted pair._1 pair._2)
+
+let _ =
+        assert
+      : benchmark iterations PairLists makePair (List Natural) runMerge size
+
+in  True

--- a/tutorial/BenchNat.dhall
+++ b/tutorial/BenchNat.dhall
@@ -1,108 +1,19 @@
 {-
-    Results for noop (the ListInt has not been constructed, linearity in S not yet visible):
+  Conclusions:
 
-    Raw table (N, S, t_sec median):
-    5000000	50000	1.048820917
-    5000000	75000	1.082226
-    5000000	100000	1.118392209
-    7500000	50000	1.537466167
-    7500000	75000	1.567287458
-    7500000	100000	1.594985625
-    10000000	50000	2.034146375
-    10000000	75000	2.05142675
-    10000000	100000	2.090238875
+  - yoneda encoding brings no performance benefits
+  - non-curried Church encoding is O(1) for head and non-empty check, while curried Church encoding is O(N) 
+  - unfix operations are slow; concat is also apparently slow
+  - benchmarking is very tricky, and results depend on the size of the resulting type, need to be careful with choosing the computation so that the result isn't too large
 
-    --- Fit: t ≈ const * N^a * S^b (OLS on log(time)) ---
-    const = 3.44157e-07
-    a     = 0.925781   (exponent on N)
-    b     = 0.06077   (exponent on S)
-
-
-    Results for ListNat/headOptional:
-
-    Raw table (N, S, t_sec median):
-    5000	5000	3.75016775
-    5000	7500	6.005081166
-    5000	10000	8.722073667
-    7500	5000	5.598937333
-    7500	7500	9.005040041
-    7500	10000	13.029334292
-    10000	5000	7.461262416
-    10000	7500	11.978271334
-    10000	10000	17.395150666
-
-    --- Fit: t ≈ const * N^a * S^b (OLS on log(time)) ---
-    const = 2.48113e-08
-    a     = 0.994704   (exponent on N)
-    b     = 1.21572   (exponent on S)
-    R² (log t) = 0.9995
-
-
-    Results for ListNat/sum:
-
-    Raw table (N, S, t_sec median):
-    5000	5000	4.41895675
-    5000	7500	6.926563292
-    5000	10000	9.95645325
-    7500	5000	6.595416041
-    7500	7500	10.374043
-    7500	10000	14.710602791
-    10000	5000	8.870872291
-    10000	7500	14.130289166
-    10000	10000	19.717812291
-
-    --- Fit: t ≈ const * N^a * S^b (OLS on log(time)) ---
-    const = 4.37683e-08
-    a     = 1.00498   (exponent on N)
-    b     = 1.15817   (exponent on S)
-    R² (log t) = 0.9995
-
-
-    Results for ListNat/length:
-
-    Raw table (N, S, t_sec median):
-    5000	5000	4.376460959
-    5000	7500	6.954222042
-    5000	10000	9.76308425
-    7500	5000	6.523111375
-    7500	7500	10.449921667
-    7500	10000	14.602839625
-    10000	5000	8.795718292
-    10000	7500	13.906055334
-    10000	10000	19.569782916
-
-    --- Fit: t ≈ const * N^a * S^b (OLS on log(time)) ---
-    const = 4.47411e-08
-    a     = 1.00272   (exponent on N)
-    b     = 1.15711   (exponent on S)
-    R² (log t) = 0.9999
-
-
-    Results for ListNat/nonEmpty:
-
-    Raw table (N, S, t_sec median):
-    5000	5000	3.880173292
-    5000	7500	6.104844833
-    5000	10000	8.656271583
-    7500	5000	5.856735459
-    7500	7500	9.195726541
-    7500	10000	13.014530709
-    10000	5000	7.802544792
-    10000	7500	12.283167167
-    10000	10000	17.400565667
-
-    --- Fit: t ≈ const * N^a * S^b (OLS on log(time)) ---
-    const = 3.92206e-08
-    a     = 1.0081   (exponent on N)
-    b     = 1.153   (exponent on S)
-    R² (log t) = 0.9997
 
     -}
 let lib =
       ./SortNatLib.dhall
         sha256:bf096188342c8e307414afa71a04dc2cddb8ff2b8cb433f6646891e505f0f77c
 
-let benchmark = ./Benchmark.dhall sha256:0d403a5bda315d97c19410cbc90ea4b1239945c71440ca28feefc61e71349e3d
+let benchmark =
+      ./Benchmark.dhall sha256:798dbc8ddbffe10990047da18ffde52d4107a96994aa11c66817b1e248df1f64
 
 let nilNat = lib.nilNat
 
@@ -121,6 +32,10 @@ let ListNat/length = lib.ListNat/length
 let makeListNat = lib.makeListNat
 
 let PairLists = lib.PairLists
+
+let Y =
+      ./ListNatYoneda.dhall
+        sha256:71161a60e1c38761374897ca013ccc3ddb201d5e47868cc4ac928ebcbbda785c
 
 let ListNat/headOptional
     : ListNat → Optional Natural
@@ -162,18 +77,259 @@ let
       λ(size : Natural) →
         benchmark iterations ListNat (makeListNat size 0 1) outputType f
 
-let test1 = mkTest ListNat noop
+let makeListNatY
+    : Natural → Natural → Natural → Y.ListNatY
+    = λ(size : Natural) →
+      λ(init : Natural) →
+      λ(delta : Natural) →
+        ( Natural/fold
+            size
+            { result : Y.ListNatY, index : Natural }
+            ( λ(acc : { result : Y.ListNatY, index : Natural }) →
+                { result = Y.ListNatY/cons acc.index acc.result
+                , index = Natural/subtract delta acc.index
+                }
+            )
+            { result = Y.ListNatY/nil
+            , index = init + Natural/subtract 1 size * delta
+            }
+        ).result
 
-let test2 = mkTest Natural ListNat/sum
+let _ = assert : Y.ListNatY/toList (makeListNatY 5 0 2) ≡ [ 0, 2, 4, 6, 8 ]
 
-let test3 = mkTest Natural ListNat/length
+let mkTestY =
+      λ(outputType : Type) →
+      λ(f : Y.ListNatY → outputType) →
+      λ(iterations : Natural) →
+      λ(size : Natural) →
+        benchmark iterations Y.ListNatY (makeListNatY size 0 1) outputType f
 
-let test4 = mkTest Bool ListNat/nonEmpty
+let LN =
+    -- List of Naturals implemented using non-curried Church encoding.
+      Y.ListNat
 
-let test5 = mkTest (Optional Natural) ListNat/headOptional
+let LN/nil = Y.ListNat/nil
 
-let test6 = mkTest ListNat identity
+let LN/cons = Y.ListNat/cons
 
-let test7 = mkTest ListNat (λ(x : ListNat) → ListNat/concat x x)
+let makeListNatL
+    : Natural → Natural → Natural → LN
+    = λ(size : Natural) →
+      λ(init : Natural) →
+      λ(delta : Natural) →
+        ( Natural/fold
+            size
+            { result : LN, index : Natural }
+            ( λ(acc : { result : LN, index : Natural }) →
+                { result = LN/cons acc.index acc.result
+                , index = Natural/subtract delta acc.index
+                }
+            )
+            { result = LN/nil, index = init + Natural/subtract 1 size * delta }
+        ).result
 
-in  { test1, test2, test3, test4, test5, test6, test7 }
+let LN/fromList = Y.ListNat/fromList
+
+let LN/toList = Y.ListNat/toList
+
+let mkTestL =
+      λ(outputType : Type) →
+      λ(f : LN → outputType) →
+      λ(iterations : Natural) →
+      λ(size : Natural) →
+        benchmark iterations LN (makeListNatL size 0 1) outputType f
+
+let _ = assert : LN/toList (makeListNatL 3 0 1) ≡ [ 0, 1, 2 ]
+
+let LN/concat = Y.ListNat/concat
+
+let LN/length = Y.ListNat/length
+
+let LN/nonEmpty = Y.ListNat/nonEmpty
+
+let LN/headOptional = Y.ListNat/headOptional
+
+let LN/unfix = Y.ListNat/unfix
+
+let LN/fix = Y.ListNat/fix
+
+let LN/sum = Y.ListNat/sum
+
+let LN/tail = λ(x : LN) → merge { Nil = LN/nil, Cons = λ(pair : { head : Natural, tail : LN }) → pair.tail } (LN/unfix x)
+
+let _ = assert : LN/tail (makeListNatL 5 0 1) ≡ makeListNatL 4 1 1
+
+let test1
+          -- median time for iterations=1000 and size=1000 is 0.033490541 seconds
+          =
+      mkTest ListNat noop
+
+let test2
+          -- median time for iterations=1000 and size=1000 is 0.346441083 seconds
+          =
+      mkTest Natural ListNat/sum
+
+let test3
+          -- median time for iterations=1000 and size=1000 is 0.347617083 seconds
+          =
+      mkTest Natural ListNat/length
+
+let test4
+          -- median time for iterations=1000 and size=1000 is 0.309712459 seconds
+          =
+      mkTest Bool ListNat/nonEmpty
+
+let test5
+          -- median time for iterations=1000 and size=1000 is 0.296896667 seconds
+          =
+      mkTest (Optional Natural) ListNat/headOptional
+
+let test6
+          -- median time for iterations=1000 and size=1000 is 0.54549875 seconds
+          =
+      mkTest ListNat identity
+
+let test7
+          -- median time for iterations=1000 and size=1000 is 1.719045042 seconds
+          =
+      mkTest ListNat (λ(x : ListNat) → ListNat/concat x x)
+
+let test8
+          -- median time for iterations=1000 and size=1000 is 1.913241791 seconds
+          =
+      mkTest (Optional { head : Natural, tail : ListNat }) lib.ListNat/uncons
+
+let test9
+          -- median time for iterations=1000 and size=1000 is 0.558496334 seconds
+          =
+      mkTest ListNat (λ(x : ListNat) → consNat 0 x)
+
+let test10
+           -- median time for iterations=1000 and size=1000 is 0.033395042 seconds
+           =
+      mkTestY Y.ListNatY (λ(x : Y.ListNatY) → Y.ListNatY/nil)
+
+let test11
+           -- median time for iterations=1000 and size=1000 is 1.382443042 seconds
+           =
+      mkTestY Y.ListNatY (λ(x : Y.ListNatY) → Y.ListNatY/cons 0 x)
+
+let test12
+           -- median time for iterations=1000 and size=1000 is 0.571812583 seconds
+           =
+      mkTestY Natural Y.ListNatY/sum
+
+let test13
+           -- median time for iterations=1000 and size=1000 is 0.5927135 seconds
+           =
+      mkTestY Natural Y.ListNatY/length
+
+let test14
+           -- median time for iterations=1000 and size=1000 is 0.033361416 seconds
+           =
+      mkTestY Bool Y.ListNatY/nonEmpty
+
+let test15
+           -- median time for iterations=1000 and size=1000 is 0.033398708 seconds
+           =
+      mkTestY (Optional Natural) Y.ListNatY/headOptional
+
+let test16
+           -- median time for iterations=1000 and size=1000 is 3.28195725 seconds
+           =
+      mkTestY (Y.ListNatF Y.ListNatY) Y.ListNatY/unfix
+
+let test17
+           -- median time for iterations=1000 and size=1000 is 5.362828583 seconds
+           =
+      mkTestY Y.ListNatY (λ(x : Y.ListNatY) → Y.ListNatY/concat x x)
+
+let test18
+           -- median time for iterations=1000 and size=1000 is 4.706773625 seconds
+           =
+      mkTestL LN (λ(x : LN) → LN/concat x x)
+
+let test19
+           -- median time for iterations=1000 and size=1000 is 0.033338166 seconds
+           =
+      mkTestL LN (λ(x : LN) → LN/nil)
+
+let test20
+           -- median time for iterations=1000 and size=1000 is 1.380798625 seconds
+           =
+      mkTestL LN (λ(x : LN) → LN/cons 0 x)
+
+let test21
+           -- median time for iterations=1000 and size=1000 is 0.57173375 seconds
+           =
+      mkTestL Natural (λ(x : LN) → LN/length x)
+
+let test22
+           -- median time for iterations=1000 and size=1000 is 0.033640125 seconds
+           =
+      mkTestL Bool (λ(x : LN) → LN/nonEmpty x)
+
+let test23
+           -- median time for iterations=1000 and size=1000 is 0.033306167 seconds
+           =
+      mkTestL (Optional Natural) (λ(x : LN) → LN/headOptional x)
+
+let test24
+           -- median time for iterations=1000 and size=1000 is 5.002143709 seconds
+           =
+      mkTestL (Y.ListNatF LN) (λ(x : LN) → LN/unfix x)
+
+let test25
+           -- median time for iterations=1000 and size=1000 is 0.569281584 seconds
+           =
+      mkTestL Natural (λ(x : LN) → LN/sum x)
+
+let test26
+           -- median time for iterations=1000 and size=1000 is 0.03483125 seconds
+           =
+      mkTestL (Optional Natural) (λ(x : LN) → LN/headOptional (LN/concat x x))
+
+let test27
+           -- median time for iterations=1000 and size=1000 is 1.536003875 seconds
+           =
+      mkTestL Natural (λ(x : LN) → LN/sum (LN/concat x x))
+
+let test28
+           -- median time for iterations=1000 and size=1000 is 0.034080875 seconds
+           =
+      mkTestL (Optional Natural) (λ(x : LN) → LN/headOptional (LN/tail x))
+let test29
+           -- median time for iterations=1000 and size=1000 is 1.321234125 seconds
+           =
+      mkTestL Natural (λ(x : LN) → LN/sum (LN/tail x))
+
+in  { test1
+    , test2
+    , test3
+    , test4
+    , test5
+    , test6
+    , test7
+    , test8
+    , test9
+    , test10
+    , test11
+    , test12
+    , test13
+    , test14
+    , test15
+    , test16
+    , test17
+    , test18
+    , test19
+    , test20
+    , test21
+    , test22
+    , test23
+    , test24
+    , test25
+    , test26
+    , test27
+    , test28
+    , test29
+    }

--- a/tutorial/Benchmark.dhall
+++ b/tutorial/Benchmark.dhall
@@ -53,15 +53,22 @@ let benchmark
                         --         (λ(result : list) → cons (f xx) result)
                         --         nil
                         --   ) in  List/length outputType results ≡ iterations
+                        -- A slowdown in Natural/fold is due to comparisons of previous and next accumulator values at each iteration.
+                        -- Let us simplify the accumulator type so that these comparisons become trivial but never true (just the accumulator).
+                        -- We force the evaluation of f using constSome, even though the result of f is discarded.
                           Natural/fold
                             iterations
-                            { _1 : outputType, _2 : Natural }
-                            ( λ(result : { _1 : outputType, _2 : Natural }) →
-                                { _1 = f xx, _2 = result._2 + 1 }
+                            Natural
+                            ( λ(prev : Natural) →
+                                merge
+                                  { None = prev
+                                  , Some = λ(_ : outputType) → prev + 1
+                                  }
+                                 (constSome iterations outputType (f xx))
                             )
-                            { _1 = f xx, _2 = 0 }
+                            0
 
-                    in  computedResult._2 ≡ iterations
+                    in  computedResult ≡ iterations
               , None = 0 ≡ 0
               }
               opt

--- a/tutorial/ListNatYoneda.dhall
+++ b/tutorial/ListNatYoneda.dhall
@@ -75,7 +75,131 @@ let _ =
 
 let _ = assert : ListNat/toList (ListNat/fromList [ 1, 2, 3 ]) ≡ [ 1, 2, 3 ]
 
-let ListNatY = LFixYonedaModule.LFixYoneda ListNatF
+let ListNat/nonEmpty
+    : ListNat → Bool
+    = λ(listNat : ListNat) →
+        listNat
+          Bool
+          ( λ(lf : ListNatF Bool) →
+              merge
+                { Nil = False
+                , Cons = λ(_ : { head : Natural, tail : Bool }) → True
+                }
+                lf
+          )
+
+let _ = assert : ListNat/nonEmpty (ListNat/fromList [ 1, 2, 3 ]) ≡ True
+
+let _ = assert : ListNat/nonEmpty (ListNat/fromList ([] : List Natural)) ≡ False
+
+let ListNat/headOptional
+    : ListNat → Optional Natural
+    = λ(listNat : ListNat) →
+        listNat
+          (Optional Natural)
+          ( λ(lf : ListNatF (Optional Natural)) →
+              merge
+                { Nil = None Natural
+                , Cons =
+                    λ(pair : { head : Natural, tail : Optional Natural }) →
+                      Some pair.head
+                }
+                lf
+          )
+
+let _ = assert : ListNat/headOptional (ListNat/fromList [ 1, 2, 3 ]) ≡ Some 1
+
+let _ =
+        assert
+      :   ListNat/headOptional (ListNat/fromList ([] : List Natural))
+        ≡ None Natural
+
+let ListNat/fix
+    : ListNatF ListNat → ListNat
+    = fix ListNatF functorListNatF
+
+let ListNat/length
+    : ListNat → Natural
+    = λ(listNat : ListNat) →
+        listNat
+          Natural
+          ( λ(lf : ListNatF Natural) →
+              merge
+                { Nil = 0
+                , Cons =
+                    λ(pair : { head : Natural, tail : Natural }) → pair.tail + 1
+                }
+                lf
+          )
+
+let ListNat/unfix
+    : ListNat → ListNatF ListNat
+    = unfix ListNatF functorListNatF
+
+let ListNat/tail
+    : ListNat → ListNat
+    = λ(listNat : ListNat) →
+        merge
+          { Nil = ListNat/nil
+          , Cons = λ(pair : { head : Natural, tail : ListNat }) → pair.tail
+          }
+          (ListNat/unfix listNat)
+
+let _ =
+      assert : ListNat/tail (ListNat/fromList ([] : List Natural)) ≡ ListNat/nil
+
+let _ =
+        assert
+      : ListNat/toList (ListNat/tail (ListNat/fromList [ 1, 2, 3 ])) ≡ [ 2, 3 ]
+
+let ListNat/sum
+    : ListNat → Natural
+    = λ(listNat : ListNat) →
+        listNat
+          Natural
+          ( λ(lf : ListNatF Natural) →
+              merge
+                { Nil = 0
+                , Cons =
+                    λ(pair : { head : Natural, tail : Natural }) →
+                      pair.head + pair.tail
+                }
+                lf
+          )
+
+let _ = assert : ListNat/sum (ListNat/fromList [ 1, 2, 3 ]) ≡ 6
+
+let _ = assert : ListNat/sum (ListNat/fromList ([] : List Natural)) ≡ 0
+
+let ListNat/concat
+    : ListNat → ListNat → ListNat
+    = λ(left : ListNat) →
+      λ(right : ListNat) →
+        left
+          ListNat
+          ( λ(lf : ListNatF ListNat) →
+              merge
+                { Nil = right
+                , Cons =
+                    λ(pair : { head : Natural, tail : ListNat }) →
+                      ListNat/cons pair.head pair.tail
+                }
+                lf
+          )
+
+let _ =
+        assert
+      :   ListNat/toList
+            ( ListNat/concat
+                (ListNat/fromList [ 1, 2, 3 ])
+                (ListNat/fromList [ 4, 5, 6 ])
+            )
+        ≡ [ 1, 2, 3, 4, 5, 6 ]
+
+let
+    -- Same things implemented using the Church-Yoneda encoding.
+    ListNatY =
+      LFixYonedaModule.LFixYoneda ListNatF
 
 let ListNatY/nil
     : ListNatY
@@ -180,15 +304,193 @@ let ListNatY/unfix
                 lf
           )
 
+let ListNatY/fix
+    : ListNatF ListNatY → ListNatY
+    = λ(lf : ListNatF ListNatY) →
+        merge
+          { Nil = ListNatY/nil
+          , Cons =
+              λ(pair : { head : Natural, tail : ListNatY }) →
+                ListNatY/cons pair.head pair.tail
+          }
+          lf
+
+let ListNatY/nonEmpty
+    : ListNatY → Bool
+    = λ(listNatY : ListNatY) →
+        let fBool
+            : ListNatF Bool
+            = listNatY Bool (λ(lf : ListNatF Bool) → False)
+
+        in  merge
+              { Nil = False
+              , Cons = λ(pair : { head : Natural, tail : Bool }) → True
+              }
+              fBool
+
+let _ = assert : ListNatY/nonEmpty (ListNatY/fromList [ 1, 2, 3 ]) ≡ True
+
+let _ =
+      assert : ListNatY/nonEmpty (ListNatY/fromList ([] : List Natural)) ≡ False
+
+let ListNatY/headOptional
+    : ListNatY → Optional Natural
+    = λ(listNatY : ListNatY) →
+        let fOptional
+            : ListNatF (Optional Natural)
+            = listNatY
+                (Optional Natural)
+                (λ(lf : ListNatF (Optional Natural)) → None Natural)
+
+        in  merge
+              { Nil = None Natural
+              , Cons =
+                  λ(pair : { head : Natural, tail : Optional Natural }) →
+                    Some pair.head
+              }
+              fOptional
+
+let _ = assert : ListNatY/headOptional (ListNatY/fromList [ 1, 2, 3 ]) ≡ Some 1
+
+let _ =
+        assert
+      :   ListNatY/headOptional (ListNatY/fromList ([] : List Natural))
+        ≡ None Natural
+
+let ListNatY/length
+    : ListNatY → Natural
+    = λ(listNatY : ListNatY) →
+        let fNatural
+            : ListNatF Natural
+            = listNatY
+                Natural
+                ( λ(lf : ListNatF Natural) →
+                    merge
+                      { Nil = 0
+                      , Cons =
+                          λ(pair : { head : Natural, tail : Natural }) →
+                            pair.tail + 1
+                      }
+                      lf
+                )
+
+        in  merge
+              { Nil = 0
+              , Cons =
+                  λ(pair : { head : Natural, tail : Natural }) → pair.tail + 1
+              }
+              fNatural
+
+let _ = assert : ListNatY/length (ListNatY/fromList [ 1, 2, 3 ]) ≡ 3
+
+let _ = assert : ListNatY/length (ListNatY/fromList ([] : List Natural)) ≡ 0
+
+let ListNatY/tail
+    : ListNatY → ListNatY
+    = λ(listNatY : ListNatY) →
+        merge
+          { Nil = ListNatY/nil
+          , Cons = λ(pair : { head : Natural, tail : ListNatY }) → pair.tail
+          }
+          (ListNatY/unfix listNatY)
+
+let _ =
+        assert
+      :   ListNatY/toList (ListNatY/tail (ListNatY/fromList [ 1, 2, 3 ]))
+        ≡ [ 2, 3 ]
+
+let _ =
+        assert
+      :   ListNatY/toList
+            (ListNatY/tail (ListNatY/fromList ([] : List Natural)))
+        ≡ ([] : List Natural)
+
+let ListNatY/sum
+    : ListNatY → Natural
+    = λ(listNatY : ListNatY) →
+        let fsum
+            : ListNatF Natural
+            = listNatY
+                Natural
+                ( λ(lf : ListNatF Natural) →
+                    merge
+                      { Nil = 0
+                      , Cons =
+                          λ(pair : { head : Natural, tail : Natural }) →
+                            pair.head + pair.tail
+                      }
+                      lf
+                )
+
+        in  merge
+              { Nil = 0
+              , Cons =
+                  λ(pair : { head : Natural, tail : Natural }) →
+                    pair.head + pair.tail
+              }
+              fsum
+
+let _ = assert : ListNatY/sum (ListNatY/fromList [ 1, 2, 3 ]) ≡ 6
+
+let _ = assert : ListNatY/sum (ListNatY/fromList ([] : List Natural)) ≡ 0
+
+let ListNatY/concat
+    : ListNatY → ListNatY → ListNatY
+    = λ(left : ListNatY) →
+      λ(right : ListNatY) →
+        LFixYonedaModule.toLFixYoneda
+          ListNatF
+          functorListNatF
+          ( LFixYonedaModule.fromLFixYoneda
+              ListNatF
+              left
+              ListNat
+              ( λ(lf : ListNatF ListNat) →
+                  merge
+                    { Nil = LFixYonedaModule.fromLFixYoneda ListNatF right
+                    , Cons =
+                        λ(pair : { head : Natural, tail : ListNat }) →
+                          ListNat/cons pair.head pair.tail
+                    }
+                    lf
+              )
+          )
+
+let _ =
+        assert
+      :   ListNatY/toList
+            ( ListNatY/concat
+                (ListNatY/fromList [ 1, 2, 3 ])
+                (ListNatY/fromList [ 4, 5, 6 ])
+            )
+        ≡ [ 1, 2, 3, 4, 5, 6 ]
+
 in  { ListNat
+    , ListNatF
+    , functorListNatF
     , ListNat/cons
     , ListNat/nil
     , ListNat/fromList
     , ListNat/toList
+    , ListNat/unfix
+    , ListNat/nonEmpty
+    , ListNat/headOptional
+    , ListNat/length
+    , ListNat/tail
+    , ListNat/fix
+    , ListNat/sum
+    , ListNat/concat
     , ListNatY
     , ListNatY/cons
     , ListNatY/nil
     , ListNatY/fromList
     , ListNatY/toList
     , ListNatY/unfix
+    , ListNatY/tail
+    , ListNatY/fix
+    , ListNatY/nonEmpty
+    , ListNatY/headOptional
+    , ListNatY/length
+    , ListNatY/sum
+    , ListNatY/concat
     }

--- a/tutorial/Set.dhall
+++ b/tutorial/Set.dhall
@@ -111,6 +111,41 @@ let functorRBTreeF =
 
 let RBTree = λ(a : Type) → LFix (RBTreeF a)
 
+let Show = λ(a : Type) → { show : a → Text }
+
+let showNatural = { show = Natural/show }
+
+let showColor
+    : Show Color
+    = { show = λ(color : Color) → merge { Red = "Red", Black = "Black" } color }
+
+let showRBTree
+    : ∀(a : Type) → Show a → Show (RBTree a)
+    = λ(a : Type) →
+      λ(showA : Show a) →
+        { show =
+            λ(t : RBTree a) →
+              t
+                Text
+                ( λ(t : RBTreeF a Text) →
+                    merge
+                      { E = "E"
+                      , T =
+                          λ(branches : BranchT a Text) →
+                                "(T "
+                            ++  showColor.show branches.color
+                            ++  " "
+                            ++  branches.left
+                            ++  " "
+                            ++  showA.show branches.value
+                            ++  " "
+                            ++  branches.right
+                            ++  ")"
+                      }
+                      t
+                )
+        }
+
 let unfixRBTree = λ(a : Type) → unfix (RBTreeF a) (functorRBTreeF a)
 
 let OrdT = < LT | EQ | GT >
@@ -133,6 +168,21 @@ let branch
                 ⫽ { left = branches.left r alg, right = branches.right r alg }
               )
           )
+
+let _ = assert : (showRBTree Natural showNatural).show (empty Natural) ≡ "E"
+
+let _ =
+        assert
+      :   (showRBTree Natural showNatural).show
+            ( branch
+                Natural
+                { color = Color.Red
+                , left = empty Natural
+                , value = 1
+                , right = empty Natural
+                }
+            )
+        ≡ "(T Red E 1 E)"
 
 let member
     : ∀(a : Type) → Ord a → ∀(x : a) → ∀(t : RBTree a) → Bool
@@ -167,57 +217,6 @@ let ordNat
         else  if Natural/equal x y
         then  OrdT.EQ
         else  OrdT.GT
-
-let example0 = empty Natural
-
-let _ = assert : member Natural ordNat 0 example0 ≡ False
-
-let example1 =
-      branch
-        Natural
-        { color = Color.Black
-        , left = empty Natural
-        , value = 1
-        , right = empty Natural
-        }
-
-let _ = assert : member Natural ordNat 0 example1 ≡ False
-
-let _ = assert : member Natural ordNat 1 example1 ≡ True
-
-let _ = assert : member Natural ordNat 2 example1 ≡ False
-
-let _ = assert : member Natural ordNat 3 example1 ≡ False
-
-let _ = assert : member Natural ordNat 4 example1 ≡ False
-
-let example12 =
-      branch
-        Natural
-        { color = Color.Red, left = example1, value = 2, right = empty Natural }
-
-let _ = assert : member Natural ordNat 0 example12 ≡ False
-
-let _ = assert : member Natural ordNat 1 example12 ≡ True
-
-let _ = assert : member Natural ordNat 2 example12 ≡ True
-
-let _ = assert : member Natural ordNat 3 example12 ≡ False
-
-let _ = assert : member Natural ordNat 4 example12 ≡ False
-
-let example13 =
-      branch
-        Natural
-        { color = Color.Black
-        , left = example12
-        , value = 3
-        , right = empty Natural
-        }
-
-let _ = assert : member Natural ordNat 1 example13 ≡ True
-
-let _ = assert : member Natural ordNat 2 example13 ≡ True
 
 let makeT
     : ∀(a : Type) → BranchT a (RBTree a) → RBTree a
@@ -525,16 +524,56 @@ let insert
 
         in  makeBlack (ins t)
 
-let example13 = insert Natural ordNat 1 (insert Natural ordNat 3 example0)
+let Set = RBTree
 
-let _ = assert : member Natural ordNat 0 example13 ≡ False
+let Set/insert = insert
 
-let _ = assert : member Natural ordNat 1 example13 ≡ True
+let Set/empty = empty
 
-let _ = assert : member Natural ordNat 2 example13 ≡ False
+let Set/member = member
 
-let _ = assert : member Natural ordNat 3 example13 ≡ True
+let Set/show = showRBTree
 
-let _ = assert : member Natural ordNat 4 example13 ≡ False
+let Set/fromList
+    : ∀(a : Type) → Ord a → List a → Set a
+    = λ(a : Type) →
+      λ(ordA : Ord a) →
+      λ(xs : List a) →
+        List/fold
+          a
+          xs
+          (Set a)
+          (λ(x : a) → λ(prev : Set a) → Set/insert a ordA x prev)
+          (empty a)
 
-in  True
+let Set/toList
+    : ∀(a : Type) → Set a → List a
+    = λ(a : Type) →
+      λ(xs : Set a) →
+        xs
+          (List a)
+          ( λ(s : RBTreeF a (List a)) →
+              merge
+                { E = [] : List a
+                , T =
+                    λ(branches : BranchT a (List a)) →
+                      branches.left # [ branches.value ] # branches.right
+                }
+                s
+          )
+
+in  { Set
+    , Show
+    , showNatural
+    , ordNat
+    , Ord
+    , Set/fromList
+    , Set/toList
+    , Set/member
+    , Set/insert
+    , Set/show
+    , Set/empty
+    , branch
+    , rebalance
+    , unfixRBTree
+    }

--- a/tutorial/Set_tests.dhall
+++ b/tutorial/Set_tests.dhall
@@ -1,0 +1,119 @@
+let S =
+      ./Set.dhall
+        sha256:c4b7d4e9db3c41df015864b22ac5b15a48b754d3e0ea422fb29ebcbac8796807
+
+let Set/toList = S.Set/toList
+
+let Set = S.Set
+
+let Set/fromList = S.Set/fromList
+
+let Set/member = S.Set/member
+
+let Set/insert = S.Set/insert
+
+let Set/show = S.Set/show
+
+let Set/empty = S.Set/empty
+
+let Show = S.Show
+
+let showNatural = S.showNatural
+
+let ordNat = S.ordNat
+
+let Ord = S.Ord
+
+let example0 = Set/empty Natural
+
+let _ = assert : Set/member Natural ordNat 0 example0 ≡ False
+
+let example1 = Set/insert Natural ordNat 1 example0
+
+let _ = assert : Set/member Natural ordNat 0 example1 ≡ False
+
+let _ = assert : Set/member Natural ordNat 1 example1 ≡ True
+
+let _ = assert : Set/member Natural ordNat 2 example1 ≡ False
+
+let _ = assert : Set/member Natural ordNat 3 example1 ≡ False
+
+let _ = assert : Set/member Natural ordNat 4 example1 ≡ False
+
+let example12 = Set/insert Natural ordNat 2 example1
+
+let _ = assert : Set/member Natural ordNat 0 example12 ≡ False
+
+let _ = assert : Set/member Natural ordNat 1 example12 ≡ True
+
+let _ = assert : Set/member Natural ordNat 2 example12 ≡ True
+
+let _ = assert : Set/member Natural ordNat 3 example12 ≡ False
+
+let _ = assert : Set/member Natural ordNat 4 example12 ≡ False
+
+let example31 =
+      Set/insert Natural ordNat 1 (Set/insert Natural ordNat 3 example0)
+
+let _ = assert : Set/member Natural ordNat 1 example31 ≡ True
+
+let _ = assert : Set/member Natural ordNat 3 example31 ≡ True
+
+let example13 =
+      Set/insert Natural ordNat 1 (Set/insert Natural ordNat 3 example0)
+
+let _ = assert : Set/member Natural ordNat 0 example13 ≡ False
+
+let _ = assert : Set/member Natural ordNat 1 example13 ≡ True
+
+let _ = assert : Set/member Natural ordNat 2 example13 ≡ False
+
+let _ = assert : Set/member Natural ordNat 3 example13 ≡ True
+
+let _ = assert : Set/member Natural ordNat 4 example13 ≡ False
+
+let _ =
+        assert
+      :   (Set/show Natural showNatural).show example12
+        ≡ "(T Black E 1 (T Red E 2 E))"
+
+let _ =
+        assert
+      :   (Set/show Natural showNatural).show example13
+        ≡ "(T Black (T Red E 1 E) 3 E)"
+
+let _ =
+        assert
+      :   (Set/show Natural showNatural).show example31
+        ≡ "(T Black (T Red E 1 E) 3 E)"
+
+let testRoundtrip =
+      λ(x : List Natural) →
+      λ(y : List Natural) →
+        Set/toList Natural (Set/fromList Natural ordNat x) ≡ y
+
+let _ = assert : testRoundtrip [ 1, 2, 3 ] [ 1, 2, 3 ]
+
+let _ = assert : testRoundtrip [ 3, 2, 1 ] [ 1, 2, 3 ]
+
+let _ =
+        assert
+      :   (Set/show Natural showNatural).show
+            (Set/fromList Natural ordNat [ 3, 2, 1 ])
+        ≡ "(T Black (T Black E 1 E) 2 (T Black E 3 E))"
+
+let _ =
+        assert
+      : testRoundtrip
+          [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+          [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+
+let _
+      -- This takes a longer time.
+      =
+        assert
+      : testRoundtrip
+          [ 3, 1, 9, 3, 2, 3, 4, 8, 10, 7, 4, 5, 6, 8 ]
+          [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+
+in  True

--- a/tutorial/m2list.dhall
+++ b/tutorial/m2list.dhall
@@ -1,0 +1,24 @@
+-- Church encoding of List as a fixpoint of F a . F a where F a r = Optional (Pair a r)
+let Pair = λ(a : Type) → λ(b : Type) → { _1 : a, _2 : b }
+
+let mkPair = λ(a : Type) →  λ(b : Type) → λ(x : a) → λ(y : b) → { _1 = x, _2 = y }
+
+let F = λ(a : Type) → λ(r : Type) → Optional (Pair a r)
+
+let FList = λ(a : Type) → ∀(r : Type) → (F a r → r) → r
+
+let QList = λ(a : Type) → ∀(r : Type) → (F a (F a r) → r) → r
+
+let qnil : ∀(a : Type) → QList a =  λ(a : Type) → λ(r : Type) → λ(f : F a (F a r) → r) → f (None (Pair a (F a r)))
+-- this does not work!
+let qcons = λ(a : Type) → λ(x : a) → λ(xs : QList a) → λ(r : Type) → λ(f : F a (F a r) → r) → f (Some { _1 = x, _2 = 9 })
+
+let qhead = λ(a : Type) → λ(xs : QList a) → xs a a (λ(x : F a (F a a)) → x)
+
+let qtail = λ(a : Type) → λ(xs : QList a) → xs a (QList a) (λ(x : F a (F a (QList a))) → x)
+
+let qisnil = λ(a : Type) → λ(xs : QList a) → xs a Bool (λ(x : F a (F a Bool)) → x == None (Pair a (F a Bool)))
+
+let qiscons = λ(a : Type) → λ(xs : QList a) → not (qisnil xs)
+
+in  True

--- a/tutorial/okasaki-red-black-tree.dhall
+++ b/tutorial/okasaki-red-black-tree.dhall
@@ -1,0 +1,540 @@
+-- Okasaki's paper on insertion operation on sets. https://www.cs.tufts.edu/comp/150FP/archive/chris-okasaki/redblack99.pdf
+-- Also see the "delete" operation https://matt.might.net/articles/red-black-delete/ https://www.classes.cs.uchicago.edu/archive/2021/winter/22300-1/lectures/RedBlackDelete/index.html
+let Functor =
+      λ(F : Type → Type) →
+        { fmap : ∀(a : Type) → ∀(b : Type) → (a → b) → F a → F b }
+
+let LFix
+    : (Type → Type) → Type
+    = λ(F : Type → Type) → ∀(r : Type) → (F r → r) → r
+
+let fix
+    : ∀(F : Type → Type) → Functor F → F (LFix F) → LFix F
+    = λ(F : Type → Type) →
+      λ(functorF : Functor F) →
+        let C = LFix F
+
+        in  λ(fc : F C) →
+            λ(r : Type) →
+            λ(frr : F r → r) →
+              let c2r
+                  : C → r
+                  = λ(c : C) → c r frr
+
+              let fmap_c2r
+                  : F C → F r
+                  = functorF.fmap C r c2r
+
+              let fr
+                  : F r
+                  = fmap_c2r fc
+
+              in  frr fr
+
+let unfix
+    : ∀(F : Type → Type) → Functor F → LFix F → F (LFix F)
+    = λ(F : Type → Type) →
+      λ(functorF : Functor F) →
+        let C = LFix F
+
+        let fmap_fix
+            : F (F C) → F C
+            = functorF.fmap (F C) C (fix F functorF)
+
+        in  λ(c : C) → c (F C) fmap_fix
+
+let Pair = λ(a : Type) → λ(b : Type) → { _1 : a, _2 : b }
+
+let ParaAlg = λ(F : Type → Type) → λ(r : Type) → F (Pair (LFix F) r) → r
+
+let paramorphism
+    : ∀(F : Type → Type) → Functor F → LFix F → ∀(r : Type) → ParaAlg F r → r
+    = λ(F : Type → Type) →
+      λ(functorF : Functor F) →
+      λ(c : LFix F) →
+      λ(r : Type) →
+      λ(fpfrr : ParaAlg F r) →
+        let algPair
+            : F (Pair (LFix F) r) → Pair (LFix F) r
+            = λ(fp : F (Pair (LFix F) r)) →
+                let resultr
+                    : r
+                    = fpfrr fp
+
+                let resultc
+                    : LFix F
+                    = fix
+                        F
+                        functorF
+                        ( functorF.fmap
+                            (Pair (LFix F) r)
+                            (LFix F)
+                            (λ(p : Pair (LFix F) r) → p._1)
+                            fp
+                        )
+
+                in  { _1 = resultc, _2 = resultr }
+
+        let resultPair
+            : Pair (LFix F) r
+            = c (Pair (LFix F) r) algPair
+
+        in  resultPair._2
+
+let Color = < Red | Black >
+
+let BranchT =
+      λ(a : Type) →
+      λ(r : Type) →
+        { color : Color, left : r, value : a, right : r }
+
+let RBTreeF = λ(a : Type) → λ(r : Type) → < E | T : BranchT a r >
+
+let functorRBTreeF =
+      λ(a : Type) →
+        { fmap =
+            λ(r : Type) →
+            λ(s : Type) →
+            λ(f : r → s) →
+            λ(t : RBTreeF a r) →
+              merge
+                { E = (RBTreeF a s).E
+                , T =
+                    λ(branches : BranchT a r) →
+                      (RBTreeF a s).T
+                        (   branches
+                          ⫽ { left = f branches.left, right = f branches.right }
+                        )
+                }
+                t
+        }
+
+let RBTree = λ(a : Type) → LFix (RBTreeF a)
+
+let unfixRBTree = λ(a : Type) → unfix (RBTreeF a) (functorRBTreeF a)
+
+let OrdT = < LT | EQ | GT >
+
+let Ord = λ(a : Type) → ∀(x : a) → ∀(y : a) → OrdT
+
+let empty
+    : ∀(a : Type) → RBTree a
+    = λ(a : Type) → λ(r : Type) → λ(alg : RBTreeF a r → r) → alg (RBTreeF a r).E
+
+let branch
+    : ∀(a : Type) → BranchT a (RBTree a) → RBTree a
+    = λ(a : Type) →
+      λ(branches : BranchT a (RBTree a)) →
+      λ(r : Type) →
+      λ(alg : RBTreeF a r → r) →
+        alg
+          ( (RBTreeF a r).T
+              (   branches
+                ⫽ { left = branches.left r alg, right = branches.right r alg }
+              )
+          )
+
+let member
+    : ∀(a : Type) → Ord a → ∀(x : a) → ∀(t : RBTree a) → Bool
+    = λ(a : Type) →
+      λ(compareA : Ord a) →
+      λ(x : a) →
+      λ(t : RBTree a) →
+        t
+          Bool
+          ( λ(t : RBTreeF a Bool) →
+              merge
+                { E = False
+                , T =
+                    λ(branches : BranchT a Bool) →
+                      merge
+                        { LT = branches.left, EQ = True, GT = branches.right }
+                        (compareA x branches.value)
+                }
+                t
+          )
+
+let Natural/lessThan = https://prelude.dhall-lang.org/Natural/lessThan
+
+let Natural/equal = https://prelude.dhall-lang.org/Natural/equal
+
+let ordNat
+    : Ord Natural
+    = λ(x : Natural) →
+      λ(y : Natural) →
+        if    Natural/lessThan x y
+        then  OrdT.LT
+        else  if Natural/equal x y
+        then  OrdT.EQ
+        else  OrdT.GT
+
+let example0 = empty Natural
+
+let _ = assert : member Natural ordNat 0 example0 ≡ False
+
+let example1 =
+      branch
+        Natural
+        { color = Color.Black
+        , left = empty Natural
+        , value = 1
+        , right = empty Natural
+        }
+
+let _ = assert : member Natural ordNat 0 example1 ≡ False
+
+let _ = assert : member Natural ordNat 1 example1 ≡ True
+
+let _ = assert : member Natural ordNat 2 example1 ≡ False
+
+let _ = assert : member Natural ordNat 3 example1 ≡ False
+
+let _ = assert : member Natural ordNat 4 example1 ≡ False
+
+let example12 =
+      branch
+        Natural
+        { color = Color.Red, left = example1, value = 2, right = empty Natural }
+
+let _ = assert : member Natural ordNat 0 example12 ≡ False
+
+let _ = assert : member Natural ordNat 1 example12 ≡ True
+
+let _ = assert : member Natural ordNat 2 example12 ≡ True
+
+let _ = assert : member Natural ordNat 3 example12 ≡ False
+
+let _ = assert : member Natural ordNat 4 example12 ≡ False
+
+let example13 =
+      branch
+        Natural
+        { color = Color.Black
+        , left = example12
+        , value = 3
+        , right = empty Natural
+        }
+
+let _ = assert : member Natural ordNat 1 example13 ≡ True
+
+let _ = assert : member Natural ordNat 2 example13 ≡ True
+
+let makeT
+    : ∀(a : Type) → BranchT a (RBTree a) → RBTree a
+    = λ(a : Type) → λ(branches : BranchT a (RBTree a)) → branch a branches
+
+let rebalance
+    {- Rebalance the top of the tree where two red nodes are adjacent. In Haskell:
+
+    rebalance B (T R (T R a x b) y c) z d  = T R (T B a x b) y (T B c z d)
+    rebalance B (T R a x (T R b y c)) z d  = T R (T B a x b) y (T B c z d)
+    rebalance B a x (T R (T R b y c) z d)  = T R (T B a x b) y (T B c z d)
+    rebalance B a x (T R b y (T R c z d))  = T R (T B a x b) y (T B c z d)
+    rebalance color a x b = T color a x b
+
+    In Dhall, this corresponds to rebalance { color, left, value, right } and the result is again a record of the same type.
+     -}
+    : ∀(a : Type) → BranchT a (RBTree a) → BranchT a (RBTree a)
+    = λ(a : Type) →
+      λ ( branches
+        : { color : Color, left : RBTree a, value : a, right : RBTree a }
+        ) →
+        let MatchType =
+            -- Possibly one of the patterns T R (T R a x b) y c - TRLeft, or T R a x (T R b y c) - TRRight.
+              < NoMatch
+              | TRLeft :
+                  { innerLeft : RBTree a
+                  , innerValue : a
+                  , innerRight : RBTree a
+                  , value : a
+                  , right : RBTree a
+                  }
+              | TRRight :
+                  { left : RBTree a
+                  , value : a
+                  , innerLeft : RBTree a
+                  , innerValue : a
+                  , innerRight : RBTree a
+                  }
+              >
+
+        let matchSubtree
+            -- Check if a subtree matches one of the patterns in MatchType.
+            : RBTree a → MatchType
+            = λ(t : RBTree a) →
+                merge
+                  { E = MatchType.NoMatch
+                  , T =
+                      λ(branches : BranchT a (RBTree a)) →
+                        merge
+                          { Black = MatchType.NoMatch
+                          , Red =
+                              merge
+                                { E =
+                                    merge
+                                      { E = MatchType.NoMatch
+                                      , T =
+                                          λ ( innerRightBranches
+                                            : BranchT a (RBTree a)
+                                            ) →
+                                            merge
+                                              { Black = MatchType.NoMatch
+                                              , Red =
+                                                  MatchType.TRRight
+                                                    { left = branches.left
+                                                    , value = branches.value
+                                                    , innerLeft =
+                                                        innerRightBranches.left
+                                                    , innerValue =
+                                                        innerRightBranches.value
+                                                    , innerRight =
+                                                        innerRightBranches.right
+                                                    }
+                                              }
+                                              innerRightBranches.color
+                                      }
+                                      (unfixRBTree a branches.right)
+                                , T =
+                                    λ ( innerLeftBranches
+                                      : BranchT a (RBTree a)
+                                      ) →
+                                      merge
+                                        { Black = MatchType.NoMatch
+                                        , Red =
+                                            MatchType.TRLeft
+                                              { innerLeft =
+                                                  innerLeftBranches.left
+                                              , innerValue =
+                                                  innerLeftBranches.value
+                                              , innerRight =
+                                                  innerLeftBranches.right
+                                              , value = branches.value
+                                              , right = branches.right
+                                              }
+                                        }
+                                        innerLeftBranches.color
+                                }
+                                (unfixRBTree a branches.left)
+                          }
+                          branches.color
+                  }
+                  (unfixRBTree a t)
+
+        in  merge
+              { Red = branches
+              , Black =
+                  -- Check whether "l" in `T B l z d` matches as `l = T R (T R a x b) y c` -  "TRLeft" or as `l = T R a x (T R b y c)` - "TRRight".
+                  merge
+                    { NoMatch
+                      -- Check whether "r" in `T B a x r` matches as `r = T R (T R b y c) z d` -  "TRLeft" or as `r = T R b y (T R c z d)` - "TRRight".
+                      =
+                        merge
+                          { NoMatch = branches
+                          , TRLeft
+                            -- We have `r = T R (T R b y c) z d`. We need to return `R (T B a x b) y (T B c z d)`.
+                            =
+                              λ ( values
+                                : { innerLeft : RBTree a
+                                  , innerValue : a
+                                  , innerRight : RBTree a
+                                  , value : a
+                                  , right : RBTree a
+                                  }
+                                ) →
+                                { color = Color.Red
+                                , left =
+                                    makeT
+                                      a
+                                      { color = Color.Black
+                                      , left = branches.left
+                                      , value = branches.value
+                                      , right = values.innerLeft
+                                      }
+                                , value = values.innerValue
+                                , right =
+                                    makeT
+                                      a
+                                      { color = Color.Black
+                                      , left = values.innerRight
+                                      , value = values.value
+                                      , right = values.right
+                                      }
+                                }
+                          , TRRight
+                            -- We have `r = T R b y (T R c z d)`. We need to return `R (T B a x b) y (T B c z d)`.
+                            =
+                              λ ( values
+                                : { left : RBTree a
+                                  , value : a
+                                  , innerLeft : RBTree a
+                                  , innerValue : a
+                                  , innerRight : RBTree a
+                                  }
+                                ) →
+                                { color = Color.Red
+                                , left =
+                                    makeT
+                                      a
+                                      { color = Color.Black
+                                      , left = branches.left
+                                      , value = branches.value
+                                      , right = values.left
+                                      }
+                                , value = values.value
+                                , right =
+                                    makeT
+                                      a
+                                      { color = Color.Black
+                                      , left = values.innerLeft
+                                      , value = values.innerValue
+                                      , right = values.innerRight
+                                      }
+                                }
+                          }
+                          (matchSubtree branches.right)
+                    , TRLeft
+                      -- We have `l = T R (T R a x b) y c`. We need to return `R (T B a x b) y (T B c z d)`.
+                      =
+                        λ ( values
+                          : { innerLeft : RBTree a
+                            , innerValue : a
+                            , innerRight : RBTree a
+                            , value : a
+                            , right : RBTree a
+                            }
+                          ) →
+                          { color = Color.Red
+                          , left =
+                              makeT
+                                a
+                                { color = Color.Black
+                                , left = values.innerLeft
+                                , value = values.innerValue
+                                , right = values.innerRight
+                                }
+                          , value = values.value
+                          , right =
+                              makeT
+                                a
+                                { color = Color.Black
+                                , left = values.right
+                                , value = branches.value
+                                , right = branches.right
+                                }
+                          }
+                    , TRRight
+                      -- We have `l = T R a x (T R b y c)`. We need to return `R (T B a x b) y (T B c z d)`.
+                      =
+                        λ ( values
+                          : { left : RBTree a
+                            , value : a
+                            , innerLeft : RBTree a
+                            , innerValue : a
+                            , innerRight : RBTree a
+                            }
+                          ) →
+                          { color = Color.Red
+                          , left =
+                              makeT
+                                a
+                                { color = Color.Black
+                                , left = values.left
+                                , value = values.value
+                                , right = values.innerLeft
+                                }
+                          , value = values.innerValue
+                          , right =
+                              makeT
+                                a
+                                { color = Color.Black
+                                , left = values.innerRight
+                                , value = branches.value
+                                , right = branches.right
+                                }
+                          }
+                    }
+                    (matchSubtree branches.left)
+              }
+              branches.color
+
+let insert
+    : ∀(a : Type) → Ord a → ∀(x : a) → ∀(t : RBTree a) → RBTree a
+    = λ(a : Type) →
+      λ(compareA : Ord a) →
+      λ(x : a) →
+      λ(t : RBTree a) →
+        let Ba = BranchT a
+
+        let Ta = RBTree a
+
+        let makeBlack
+            : Ba Ta → Ta
+            = λ(branches : Ba Ta) →
+                branch a (branches ⫽ { color = Color.Black })
+
+        let ins
+            -- Insert x into the given tree s; will always return a T node, so we make it return a Ba Ta.
+            : Ta → Ba Ta
+            = λ(s : Ta) →
+                let palg
+                    : ParaAlg (RBTreeF a) (Ba Ta)
+                    = λ(b : RBTreeF a (Pair Ta (Ba Ta))) →
+                        merge
+                          { E =
+                            { color = Color.Red
+                            , left = empty a
+                            , value = x
+                            , right = empty a
+                            }
+                          , T =
+                              λ ( branches
+                                : { color : Color
+                                  , left : Pair Ta (Ba Ta)
+                                  , value : a
+                                  , right : Pair Ta (Ba Ta)
+                                  }
+                                ) →
+                                merge
+                                  { LT =
+                                      rebalance
+                                        a
+                                        (   branches
+                                          ⫽ { left = makeT a branches.left._2
+                                            , right = branches.right._1
+                                            }
+                                        )
+                                  , EQ =
+                                        branches
+                                      ⫽ { left = branches.left._1
+                                        , right = branches.right._1
+                                        }
+                                  , GT =
+                                      rebalance
+                                        a
+                                        (   branches
+                                          ⫽ { left = branches.left._1
+                                            , right = makeT a branches.right._2
+                                            }
+                                        )
+                                  }
+                                  (compareA x branches.value)
+                          }
+                          b
+
+                in  paramorphism (RBTreeF a) (functorRBTreeF a) s (Ba Ta) palg
+
+        in  makeBlack (ins t)
+
+let example13 = insert Natural ordNat 1 (insert Natural ordNat 3 example0)
+
+let _ = assert : member Natural ordNat 0 example13 ≡ False
+
+let _ = assert : member Natural ordNat 1 example13 ≡ True
+
+let _ = assert : member Natural ordNat 2 example13 ≡ False
+
+let _ = assert : member Natural ordNat 3 example13 ≡ True
+
+let _ = assert : member Natural ordNat 4 example13 ≡ False
+
+in  True

--- a/tutorial/runbench1.sh
+++ b/tutorial/runbench1.sh
@@ -1,0 +1,4 @@
+a=$1
+echo "let b = ./BenchNat.dhall in assert : b.test$a (env:N ? 3) (env:S ? 3)" > xbench.dhall ; cat xbench.dhall; nu benchmark_sortnat.nu xbench.dhall $2 $3
+
+

--- a/tutorial/xbench.dhall
+++ b/tutorial/xbench.dhall
@@ -1,0 +1,1 @@
+let b = ./BenchNat.dhall in assert : b.test29 (env:N ? 3) (env:S ? 3)


### PR DESCRIPTION
Add implementation of Okasaki's red-black tree with insertion and member functions.

See:
- Okasaki's paper, `insert` operation on sets. https://www.cs.tufts.edu/comp/150FP/archive/chris-okasaki/redblack99.pdf
- For the "delete" operation: https://matt.might.net/articles/red-black-delete/ https://www.classes.cs.uchicago.edu/archive/2021/winter/22300-1/lectures/RedBlackDelete/index.html